### PR TITLE
[arch][x86] update x86 TSS and IDT

### DIFF
--- a/arch/x86/64/exceptions.S
+++ b/arch/x86/64/exceptions.S
@@ -25,12 +25,18 @@
 #include <asm.h>
 #include <arch/x86/descriptor.h>
 
-#define NUM_INT 0x31
+#define NUM_INT 0x100
 #define NUM_EXC 0x14
 
 .text
 
 /* interrupt service routine stubs */
+
+/*
+ * pushq $i occupies 5 bytes when i >= 0x80 compare to
+ * 2 bytes when i < 0x80, use align to fill the gap
+ * to make sure isr_stub_len correct for each interrupts
+ */
 _isr:
 .set i, 0
 .rept NUM_INT
@@ -38,14 +44,18 @@ _isr:
 .set isr_stub_start, .
 
 .if i == 8 || (i >= 10 && i <= 14) || i == 17
-        nop                                     /* error code pushed by exception */
-        nop                                     /* 2 nops are the same length as push byte */
-        pushq $i                                /* interrupt number */
-        jmp interrupt_common
+.align 16
+    nop             /* error code pushed by exception */
+    nop             /* 2 nops are the same length as push byte */
+    pushq $i        /* interrupt number */
+    jmp interrupt_common
+.align 16
 .else
-        pushq $0                                /* fill in error code in iframe */
-        pushq $i                                /* interrupt number */
-        jmp interrupt_common
+.align 16
+    pushq $0        /* fill in error code in iframe */
+    pushq $i        /* interrupt number */
+    jmp interrupt_common
+.align 16
 .endif
 
 /* figure out the length of a single isr stub (usually 6 or 9 bytes) */
@@ -137,7 +147,7 @@ DATA(_idtr)
 DATA(_idt)
 
 .set i, 0
-.rept NUM_INT-1
+.rept NUM_INT
     .short 0        /* low 16 bits of ISR offset (_isr#i & 0FFFFh) */
     .short CODE_64_SELECTOR   /* selector */
     .byte  0

--- a/arch/x86/gdt.S
+++ b/arch/x86/gdt.S
@@ -56,85 +56,89 @@ DATA(_gdt)
 _code_32_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10011010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
     .byte  0b11001111       /* G(1) D(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set datasel, . - _gdt
 _data_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10010010       /* P(1) DPL(00) S(1) 0 E(0) W(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set user_codesel_32, . - _gdt
 _user_code_32_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
     .byte  0b11001111       /* G(1) D(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 
 .set user_datasel, . - _gdt
 _user_data_32_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set codesel_64, . - _gdt
 _code_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10011010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
     .byte  0b10101111       /* G(1) D(0) L(1) AVL(0) limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set datasel_64, . - _gdt
 _data_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b10010010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 AVL(0) limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set user_codesel_64, . - _gdt
 _user_code_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
     .byte  0b10101111       /* G(1) D(1) L(0) AVL(0) limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 .set user_datasel_64, . - _gdt
 _user_data_64_gde:
     .short 0xffff           /* limit 15:00 */
     .short 0x0000           /* base 15:00 */
-    .byte  0x00         /* base 23:16 */
+    .byte  0x00             /* base 23:16 */
     .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
-    .byte  0x0          /* base 31:24 */
+    .byte  0x0              /* base 31:24 */
 
 /* TSS descriptor */
 .set tsssel, . - _gdt
 _tss_gde:
+.set i, 1
+.rept SMP_MAX_CPUS
     .short 0                /* limit 15:00 */
     .short 0                /* base 15:00 */
     .byte  0                /* base 23:16 */
-    .byte  0x89             /* P(1) DPL(11) 0 10 B(0) 1 */
-    .byte  0x80             /* G(0) 0 0 AVL(0) limit 19:16 */
-    .byte  0               /* base 31:24 */
+    .byte  0x89             /* P(1) DPL(00) S(0) TYPE(9) */
+    .byte  0x80             /* G(1) D/B(0) L(0) AVL(0) limit 19:16 */
+    .byte  0                /* base 31:24 */
     .quad  0x0000000000000000
+.set i, i+1
+.endr
 
 DATA(_gdt_end)
 


### PR DESCRIPTION
1. Update TSS selector description.
2. Enlarge TSS selector up to SMP_MAX_CPUS.
3. Enlarge interrupt numbers support to 0xFF in arch x86-64.

Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>